### PR TITLE
Fixed DataPage assert error.

### DIFF
--- a/awake/operand.py
+++ b/awake/operand.py
@@ -98,7 +98,10 @@ class ComplexValue(Operand):
 class AddressConstant(Constant):
     def __init__(self, addr):
         if not hasattr(addr, 'virtual'):
-            addr = address.fromVirtual(addr)
+            if isinstance(addr, int):                       #If addr is an int,
+                addr = address.fromVirtual(addr)            #   code path is unchanged.
+            else:                                           #Else, addr is a string,
+                addr = address.fromConventional(addr)       #   so it should be processed by fromConventional.
         super(AddressConstant, self).__init__(addr.virtual())
         self.addr = addr
         self.value = addr.virtual()


### PR DESCRIPTION
When a DataPage is displayed, this tries to pass a string to address.fromVirtual(), causing an AssertionError. 

Fixed by checking type of addr. If it is a string, pass to address.fromConventional() instead.
